### PR TITLE
Update external groups

### DIFF
--- a/apis/slack.py
+++ b/apis/slack.py
@@ -125,7 +125,7 @@ def get_user_names(user_ids):
             
     return users_names
     
-def update_employees(user_ids, user_group_id):
+def update_usergroup_users(user_group_id, user_ids):
     """Function creates a 'get' request, in order to update the list of user in a user group, by passing the token as a parameter for authentication,
         a list of userIDs, and the id of the user_group.
 

--- a/apis/slack.py
+++ b/apis/slack.py
@@ -142,7 +142,9 @@ def update_usergroup_users(user_group_id, user_ids):
     data = []
     try:
         request = requests.get('https://slack.com/api/usergroups.users.update', 
-                params = {'token': token.get_slack_token(), 'usergroup': user_group_id, 'users': user_ids},
+                params = {'token': token.get_slack_token(), 
+                        'usergroup': user_group_id, 
+                        'users': user_ids},
                 headers = {'Connection': 'close'} )
                 
         data = request.json()
@@ -151,7 +153,6 @@ def update_usergroup_users(user_group_id, user_ids):
         print(e)
             
     return data
-    
     
 
 def get_user_list():
@@ -166,7 +167,6 @@ def get_user_list():
 
     """
     data = []
-    
     try:
         request = requests.get('https://slack.com/api/users.list', 
                 params = {'token': token.get_slack_token()},
@@ -178,6 +178,7 @@ def get_user_list():
         print(e)
     
     return data
+    
     
 def get_user_groups_list():
     """Function creates a 'get'request, in order to get all the information from the groups in the Slack channel,
@@ -191,7 +192,6 @@ def get_user_groups_list():
 
     """
     data = []
-    
     try:
         request = requests.get('https://slack.com/api/usergroups.list', 
                 params = {'token': token.get_slack_token()},
@@ -204,3 +204,29 @@ def get_user_groups_list():
     
     return data
     
+
+def get_usergroup_users_list(usergroup_id):
+    """Returns a list with the ids of the users in a usergroup.
+    
+    Args:
+        usergroup_id: The id of a Slack usergroup.
+        
+    Returns:
+        Returns a list containing the ids of the users in the
+        specified usergroup.
+    """
+    user_ids = []
+    try:
+        request = requests.get('https://slack.com/api/usergroups.users.list', 
+                params = {'token': token.get_slack_token(),
+                        'usergroup': usergroup_id },
+                headers = {'Connection': 'close'})
+        
+        data = request.json()
+        if data.get('ok'):
+            user_ids = data.get('users')
+        
+    except Exception as e:
+        print(e)
+        
+    return user_ids

--- a/db/database.py
+++ b/db/database.py
@@ -58,6 +58,7 @@ def get_all_instances(model):
     except Exception as e:
         session.rollback()
     
+    session.close()
     return results
 
 
@@ -85,6 +86,7 @@ def get_instance_by_field(model, field, value):
     except Exception as e:
         session.rollback()
     
+    session.close()
     return result
     
 def get_instances_by_field(model, field, value):
@@ -106,6 +108,7 @@ def get_instances_by_field(model, field, value):
     except Exception as e:
         session.rollback()
     
+    session.close()
     return results
 
 
@@ -144,6 +147,7 @@ def update_instance(instance):
         # Todo: Log the error (Find specific errors that can happen)
         session.rollback()
 
+    session.close()
     return is_updated
 
 
@@ -173,5 +177,6 @@ def remove_instance_by_field(model, field, value):
     except:
         # Todo: Add exception cases
         session.rollback()
-
+        
+    session.close()
     return is_deleted

--- a/db/database.py
+++ b/db/database.py
@@ -58,7 +58,6 @@ def get_all_instances(model):
     except Exception as e:
         session.rollback()
     
-    session.close()
     return results
 
 
@@ -86,7 +85,6 @@ def get_instance_by_field(model, field, value):
     except Exception as e:
         session.rollback()
     
-    session.close()
     return result
     
 def get_instances_by_field(model, field, value):
@@ -108,7 +106,6 @@ def get_instances_by_field(model, field, value):
     except Exception as e:
         session.rollback()
     
-    session.close()
     return results
 
 
@@ -147,7 +144,6 @@ def update_instance(instance):
         # Todo: Log the error (Find specific errors that can happen)
         session.rollback()
 
-    session.close()
     return is_updated
 
 
@@ -178,5 +174,4 @@ def remove_instance_by_field(model, field, value):
         # Todo: Add exception cases
         session.rollback()
         
-    session.close()
     return is_deleted

--- a/db/encode.py
+++ b/db/encode.py
@@ -1,4 +1,4 @@
-from db.models import Model, User, Employee, App, Role, Group, EmployeeToRole, RoleToGroup, AppToGroup
+from db.models import Model, User, Employee, App, Role, Group, EmployeeToRole, RoleToGroup
 from db import query
 import json
 

--- a/db/models.py
+++ b/db/models.py
@@ -24,6 +24,7 @@ class Model():
         """
         return filter_dictionary(dict(self.__dict__), excludes )
 
+
 class User(Base, Model):
     """The model for the user table.
     
@@ -98,14 +99,17 @@ class Employee(Base, Model):
     email = Column('email', String(255) )
     first_name = Column('first_name', String(255) )
     last_name = Column('last_name', String(255) )
+    slack_id = Column('slack_user_id', String(255) )
     
     roles = association_proxy('employee_roles', 'role')
 
 
-    def __init__(self, email: str, first_name: str, last_name: str):
+    def __init__(self, email: str, first_name: str, last_name: str, 
+                slack_id: str = ""):
         self.email = email
         self.first_name = first_name
         self.last_name = last_name
+        self.slack_id = slack_id
 
 
     def __repr__(self):
@@ -137,9 +141,7 @@ class App(Base, Model):
 
     id = Column('app_id', Integer, primary_key = True)
     name = Column('name', String(255) )
-
-    groups = association_proxy('app_groups', 'group')
-
+    
 
     def __init__(self, name: str, token: str = ""):
         self.name = name
@@ -212,15 +214,17 @@ class Group(Base, Model):
     id = Column('group_id', Integer, primary_key = True)
     name = Column('name', String(255) )
     app_group_id = Column('app_group_id', String(255) )
+    app_id = Column('app_id', String(255), ForeignKey('app.app_id') )
     
-
-    def __init__(self, name, app_group_id):
+    
+    def __init__(self, name, app_group_id, app_id):
         self.name = name
         self.app_group_id = app_group_id
+        self.app_id = app_id
     
     def __repr__(self):
         str_format = '<Group(name: %s)>'
-        values = (self.id, self.name)
+        values = (self.name)
         return str_format % values
 
 
@@ -241,7 +245,6 @@ class EmployeeToRole(Base, Model):
                 backref = backref('employee_roles',
                           cascade = 'all, delete-orphan')
                 )
-    
     role = relationship('Role')
     
     
@@ -272,7 +275,6 @@ class RoleToGroup(Base, Model):
                 backref = backref('role_groups',
                           cascade = 'all, delete-orphan')
             )
-
     group = relationship('Group')
 
 
@@ -280,40 +282,9 @@ class RoleToGroup(Base, Model):
         self.role = role
         self.group = group
 
+
     def __repr___(self):
         str_format = '<RoleToGroup(group_id: %d, role_id: %d)>'
         values = (self.group_id, self.role_id)
         return str_format % values
-
-
-class AppToGroup(Base, Model):
-    """The model for the app_group table.
-
-    Attributes:
-        app_id: (str): Foreign key, from the app table.
-        group_id (int): Foreign key, from the group table.
-
-    """
-    __tablename__ = 'app_group'
-
-    app_id = Column('app_id', Integer, ForeignKey('app.app_id'), primary_key = True)
-    group_id = Column('group_id', Integer, ForeignKey('group.group_id'), primary_key = True)
-    
-    
-    app = relationship(App, 
-                backref = backref('app_groups', 
-                            cascade = 'all, delete-orphan')
-            )
-            
-    group = relationship('Group')
-
-
-    def __init__(self, group = None, app = None):
-        self.app = app
-        self.group = group
-
-
-    def __repr___(self):
-        str_format = '<AppToGroup(app_id: %d, group_id: %d)>'
-        values = (self.app_id, self.group_id)
-        return str_format % values
+        

--- a/db/models.py
+++ b/db/models.py
@@ -216,7 +216,6 @@ class Group(Base, Model):
 
     def __init__(self, name, app_group_id):
         self.name = name
-
         self.app_group_id = app_group_id
     
     def __repr__(self):

--- a/db/query.py
+++ b/db/query.py
@@ -1,7 +1,7 @@
 from typing import List
 from db.database import Session
 from db.models import User, Employee, App, Role, Group,\
-        EmployeeToRole, RoleToGroup, AppToGroup
+        EmployeeToRole, RoleToGroup
 from db.database import get_all_instances, get_instance_by_field,\
         get_instances_by_field, add_instance, update_instance,\
         remove_instance_by_field
@@ -410,36 +410,6 @@ def get_employee_roles(email: str) -> List[EmployeeToRole]:
     return session.query(EmployeeToRole).filter(EmployeeToRole.email == email).all()
 
 
-def get_all_employees_with_roles() -> List[EmployeeToRole]:
-    """Query to find all the roles each employee has.
-
-    Returns:
-        Returns a list of employee email, and the associated roles.
-    """
-    session = Session()
-    return session.query(Employee, Role).filter(Employee.email == EmployeeToRole.email).filter(Role.id == EmployeeToRole.id).all()
-
-
-def get_all_groups_with_roles() -> List[RoleToGroup]:
-    """Query to find all groups and their assigned roles.
-
-    Returns:
-        Returns a list of groups and their assigned roles.
-    """
-    session = Session()
-    return session.query(Group, Role).filter(Group.id == RoleToGroup.group_id).filter(Role.id == RoleToGroup.role_id).all()
-
-
-def get_all_apps_with_groups() -> List[AppToGroup]:
-    """Query to find all groups and which apps they use.
-
-    Returns:
-        Returns a list of groups and which apps they use.
-    """
-    session = Session()
-    return session.query(App, Group).filter(Group.id == AppToGroup.group_id).filter(App.id == AppToGroup.app_id).all()
-
-
 def delete_multiple_employees(ids: List[int]) -> bool:
     """Removes all employees with a matching id.
     
@@ -448,3 +418,18 @@ def delete_multiple_employees(ids: List[int]) -> bool:
     """
     pass
     
+
+def get_slack_groups() -> List[Group]:
+    """Returns a list of groups that belong to Slack.
+    
+    Returns:
+        Returns a list containing all the groups from Slack.
+    """
+    groups = None
+    session = Session()
+    try:
+        groups = session.query(Group).filter(Group.app_id == 1).all()
+    except Exception as e:
+        print(e)
+        
+    return groups

--- a/synchronization/sync.py
+++ b/synchronization/sync.py
@@ -1,7 +1,7 @@
 from apis import slack
 from synchronization import utils
 from db import query
-from db.models import Group
+from db.models import Group, Employee
 
 
 def sync_slack_users():
@@ -48,14 +48,13 @@ def sync_slack_users():
     
   
 def sync_slack_groups():
-    """Function adds all the groups from the Slack team that are not in the database to the database
+    """Syncs the groups from the Slack team with the gorups in the database.
 
     Args:
         none
 
     Returns:
         none
-
     """
     data = slack.get_user_groups_list()
     api_ids = utils.get_slack_api_group_id(data)
@@ -78,6 +77,25 @@ def sync_slack_groups():
                 if group["id"] == id:
                     if "name" in group:
                         name = group["name"]
-                        group_obj = Group(None, name, 1, group["id"])
+                        group_obj = Group(name, group["id"])
                         query.update_group(group_obj)
                         
+                        
+def add_to_group(group: Group, employees: Employee) -> bool:
+    """Adds the passed in employee to the passed in group in the appropriate app.
+    
+    Args:
+        group: A group from one of the integrated apps.
+        employee: An employee that may be a user.
+        
+    Returns:
+        Returns true if the employee is successfully added to the gruop, 
+        otherwise, returns false.
+    """
+    pass
+
+
+def remove_from_group(group: Group, employees: Employee) -> bool:
+    """
+    """
+    pass

--- a/synchronization/utils.py
+++ b/synchronization/utils.py
@@ -1,4 +1,6 @@
 from apis import slack
+from db import query
+from db.models import Group, Employee
 
 
 def parse_emails_from_slack_users(data):
@@ -18,7 +20,7 @@ def parse_emails_from_slack_users(data):
     return emails
     
     
-def parse_ids_from_slack_usergroup(data):
+def parse_ids_from_slack_usergroups(data):
     """Parses the usergroup ids from a dictionary with Slack usergroup data.
 
     Args:
@@ -26,6 +28,64 @@ def parse_ids_from_slack_usergroup(data):
             in the Slack team.
 
     Returns:
-        Returns a list containing all the group_ids in the slack Team.
+        Returns a list containing all the group ids in the Slack team.
     """
-    return [usergroup["id"] for usergroup in data["usergroups"]]
+    return [usergroup.get("id") for usergroup in data.get("usergroups")]
+    
+    
+def parse_ids_from_slack_users(data):
+    """Parses the user ids from a dictionary with Slack user data.
+    
+    Args:
+        data: A dictionary containing information for each user 
+            in the Slack team.
+        
+    Returns:
+        Returns a list containing all the user ids in the Slack team.
+    """
+    return [member.get("id") for member in data.get("members")]
+    
+
+def parse_user_ids_from_slack_usergroup(data):
+    """Parses the user ids from a dictionary with an updated Slack usergroup.
+    
+    Args:
+        data: A dictionary containing information for the
+            updated usergroup from Slack.
+            
+    Returns:
+        Returns a list of the user ids from a Slack usergroup.
+    """
+    return [user_id for user_id in data.get('usergroup').get('users')]
+    
+    
+def get_missing_group_ids(slack_usergroups, groups):
+    """Returns the ids of Slack usergroups that are not already in the database.
+    
+    Args:
+        slack_usergroups: A dictionary with data from the Slack 
+            usergroups.list endpoint.
+        groups: A list of Group instances that are from Slack.
+    
+    Returns:
+        Returns a list of ids belonging to Slack usergroups 
+        that are not in the database.
+    """
+    slack_ids = set(parse_ids_from_slack_usergroups(slack_usergroups) )
+    db_ids = {group.app_group_id for group in groups}
+    missing_ids = slack_ids - db_ids
+    
+    return missing_ids
+    
+    
+def get_missing_user_ids(slack_users, users):
+    """Returns the ids of Slack users that are not already in the database.
+    
+    Args:
+        slack_users: A dictionary with a list of users from slack.
+    """
+    slack_ids = set(parse_ids_from_slack_users(slack_users) )
+    db_ids = {user.slack_id for user in users}
+    missing_ids = slack_ids - db_ids
+    
+    return missing_ids

--- a/synchronization/utils.py
+++ b/synchronization/utils.py
@@ -1,43 +1,31 @@
 from apis import slack
 
 
-def get_slack_api_emails(data):
-    """Function parses all the emails from a dictionary containing all the Slack Team member's information
+def parse_emails_from_slack_users(data):
+    """Parses the the emails from a dictionary with Slack user information.
 
     Args:
         data: a dictionary containing all the information from each user in the Slack team
 
     Returns:
-        Returns a list containing all the emails in the slack Team.
-
-    """
-    data = slack.get_user_list()
-    users_emails = []
-    member_amt = len(data["members"])
-        
-    for i in range(0, member_amt):
-        profile_amt = len(data["members"][i]["profile"])
+        Returns a list containing all  emails from the slack team.
+    """            
+    emails = []
+    for user in data["members"]:
+        if "profile" in user and "email" in user["profile"]:
+            emails.append(user["profile"]["email"])
             
-        profile = (data["members"][i])["profile"]
-        if "email" in profile:
-            users_emails.append(profile["email"])
-            
-    return users_emails
+    return emails
     
     
-def get_slack_api_group_id(data):
-    """Function parses all the group_ids from a dictionary containing all the Slack Team groups's information
+def parse_ids_from_slack_usergroup(data):
+    """Parses the usergroup ids from a dictionary with Slack usergroup data.
 
     Args:
-        data: a dictionary containing all the information from each group in the Slack team
+        data: a dictionary containing information for each group 
+            in the Slack team.
 
     Returns:
         Returns a list containing all the group_ids in the slack Team.
-
     """
-    group_ids = []
-        
-    for group in data["usergroups"]:
-        group_ids.append(group["id"])
-    
-    return group_ids
+    return [usergroup["id"] for usergroup in data["usergroups"]]

--- a/tests/slack_test.py
+++ b/tests/slack_test.py
@@ -37,7 +37,7 @@ class testSlackFunctions(unittest.TestCase):
         self.assertIsNotNone(userNames)
             
             
-    def test_update_employees(self):
+    def test_update_usergroup_users(self):
         group_names = slack.get_user_groups()
         first_group_name = group_names[0]
         group_ids = slack.get_user_group_ids()
@@ -66,7 +66,7 @@ class testSlackFunctions(unittest.TestCase):
         
         # Call the function to update the userlist
         comma_separated_user_ids = ",".join(user_ids)
-        slack.update_employees(comma_separated_user_ids, first_group_id)
+        slack.update_usergroup_users(comma_separated_user_ids, first_group_id)
         
         updated_user_list = slack.get_users(first_group_name)
         print("Testing slack list: after remove:")
@@ -74,7 +74,7 @@ class testSlackFunctions(unittest.TestCase):
         
         user_ids.append(first_user_id)
         comma_separated_user_ids = ",".join(user_ids)
-        slack.update_employees(comma_separated_user_ids, first_group_id)
+        slack.update_usergroup_users(comma_separated_user_ids, first_group_id)
         
         updated_user_list = slack.get_users(first_group_name)
         print("Testing slack list: after adding user back:")


### PR DESCRIPTION
**Description:**
I refactored the code for syncing the employees and the groups. I also updated the database schema to include the ids of groups and users, so that updates can be made more quickly. Employees can now be removed and added from the usergroups on Slack, although, this is not connected to our DELETE and PUT methods for employees and roles.

**Test Plan:**
No test plan.