### PR TITLE
Fixed error with get_json error

### DIFF
--- a/views/roles.py
+++ b/views/roles.py
@@ -99,7 +99,7 @@ def role_uri():
 
 @roles.route('/api/roles', methods = ['GET', 'DELETE'])
 def roles_uri():
-    args = request.get_json()
+    args = request.get_json(silent = True)
     
     if request.method == 'GET':
         try:


### PR DESCRIPTION
**Description:**
I made the `request.get_json()` function in the `/api/roles` GET request silently fail. Before it would cause an exception if there was not to decode. Now it returns None when there is no json.

**Test Plan:**
Verify roles load into the drop down for the add employee page. 