### PR TITLE
Slack users update when role is given to employees

### DIFF
--- a/dashboard/static/js/Roles.js
+++ b/dashboard/static/js/Roles.js
@@ -90,6 +90,57 @@ $(document).ready(function(){
         return tblRow;
     }
     
+    $('#save').click(function(){
+        
+        
+        var groupsSelected = $('#groups').val()
+        
+        console.log(groupsSelected)
+        
+        
+        var rolesSelected = [];
+        
+        $('.checkbox:checkbox:checked').each(function() {
+            rolesSelected.push($(this).val());
+        });
+        
+        var data = {
+            
+            'role_ids': rolesSelected,
+            'group_ids': groupsSelected
+            
+        }
+        
+        console.log(rolesSelected);
+        
+        $.ajax({
+            url: '/api/roles/groups',
+            method: 'PUT',
+            data: JSON.stringify(data),
+            contentType: 'application/json',
+            success: function(response) {
+                $('#message').html("Group was added");
+                $('#alert-message')[0].classList.add('alert-success');
+                $('#alert-message').show();
+                
+                clearTable(response);
+               
+            },
+            error: function(error) {
+                try {
+                    json = JSON.parse(error.responseText);
+                    if (json.message) {
+                        $('#message').html(json.message);
+                        $('#alert-message')[0].classList.add('alert-danger');
+                        $('#alert-message').show();
+                    }
+                }
+                catch (e) {
+                    console.log(e);
+                }
+            }
+        });
+    });
     
     function getGroupNames(groups) {
         var names = groups.map(function(group) {

--- a/db/query.py
+++ b/db/query.py
@@ -419,7 +419,7 @@ def get_employee_roles(email: str) -> List[EmployeeToRole]:
     session = Session()
     return session.query(EmployeeToRole).filter(EmployeeToRole.email == email).all()
     
-def get_roles_groups(role_id: int) -> List[Group]:
+def get_role_groups(role_id: int) -> List[Group]:
     """Returns a list of groups with the given role.
 
     Args:
@@ -470,6 +470,46 @@ def get_employees_by_role(role: Role) -> List[Employee]:
     try:
         employees = session.query(Employee).filter(Role.id == role.id).all()
     
+    except Exception as e:
+        print(e)
+        
+    return employees
+    
+    
+def get_roles_with_ids(ids: List[int]) -> List[Role]:
+    """Returns a list of roles that match the specified ids.
+    
+    Args:
+        ids: The ids being used to query roles.
+        
+    Returns: 
+        Returns a list of roles.
+    """
+    session = Session()
+    roles = []
+    try:
+        roles = session.query(Role).filter(Role.id.in_(ids) ).all()
+        
+    except Exception as e:
+        print(e)
+        
+    return roles
+    
+    
+def get_employees_with_ids(ids: List[int]) -> List[Employee]:
+    """Returns a list of employees that match the specified ids.
+    
+    Args:
+        ids: The ids being used to query employees.
+        
+    Returns: 
+        Returns a list of employess.
+    """
+    session = Session()
+    employees = []
+    try:
+        employees = session.query(Employee).filter(Employee.id.in_(ids) ).all()
+        
     except Exception as e:
         print(e)
         

--- a/db/query.py
+++ b/db/query.py
@@ -419,7 +419,7 @@ def get_employee_roles(email: str) -> List[EmployeeToRole]:
     session = Session()
     return session.query(EmployeeToRole).filter(EmployeeToRole.email == email).all()
     
-def get_roles_groups(role_id: str) -> List[RoleToGroup]:
+def get_roles_groups(role_id: int) -> List[Group]:
     """Returns a list of groups with the given role.
 
     Args:
@@ -429,9 +429,7 @@ def get_roles_groups(role_id: str) -> List[RoleToGroup]:
         Returns a list of groups if an role has the role_id, otherwise returns None.
     """
     session = Session()
-    session.query(RoleToGroup).filter(RoleToGroup.role_id == role_id).all()
-    groups = session.query(Group).filter(RoleToGroup.group_id == Group.id).all()
-    return groups
+    return session.query(Group).join(RoleToGroup).filter(RoleToGroup.role_id == role_id).all()
 
 def delete_multiple_employees(ids: List[int]) -> bool:
     """Removes all employees with a matching id.

--- a/db/query.py
+++ b/db/query.py
@@ -418,7 +418,20 @@ def get_employee_roles(email: str) -> List[EmployeeToRole]:
     """
     session = Session()
     return session.query(EmployeeToRole).filter(EmployeeToRole.email == email).all()
+    
+def get_roles_groups(role_id: str) -> List[RoleToGroup]:
+    """Returns a list of groups with the given role.
 
+    Args:
+        role_id: An role's role_id.
+
+    Returns:
+        Returns a list of groups if an role has the role_id, otherwise returns None.
+    """
+    session = Session()
+    session.query(RoleToGroup).filter(RoleToGroup.role_id == role_id).all()
+    groups = session.query(Group).filter(RoleToGroup.group_id == Group.id).all()
+    return groups
 
 def delete_multiple_employees(ids: List[int]) -> bool:
     """Removes all employees with a matching id.

--- a/group_assignment_tool.sql
+++ b/group_assignment_tool.sql
@@ -126,9 +126,12 @@ CREATE TABLE IF NOT EXISTS `role` (
 -- Dumping data for table `role`
 --
 
+
 INSERT INTO `role` (`role_id`, `name`, `description`) VALUES
 (3, 'Marketing', 'Manages communication with the customers.'),
-(4, 'Developer', 'A general developer.');
+(4, 'Developer', 'A general developer.'),
+(8, 'Test', ''),
+(9, 'Role Name', 'This is a description.');
 
 -- --------------------------------------------------------
 
@@ -143,6 +146,13 @@ CREATE TABLE IF NOT EXISTS `role_group` (
   KEY `role_group_ibfk_2` (`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+
+
+INSERT INTO `role_group` (`role_id`, `group_id`) VALUES
+(8, 10),
+(9, 10),
+(8, 11),
+(9, 11);
 -- --------------------------------------------------------
 
 --

--- a/synchronization/sync.py
+++ b/synchronization/sync.py
@@ -58,8 +58,7 @@ def add_to_slack_group(group: Group, employees: List[Employee]) -> List[str]:
             in Slack or Bugzilla.
         
     Returns:
-        Returns a set of ids of the employees added to the group. An empty
-        list is retured if no employees are added.
+        Returns a set of ids of the employees in the group.
     """
     client = slack.SlackClient(token.get_slack_token())
     group_id = group.app_group_id
@@ -70,9 +69,8 @@ def add_to_slack_group(group: Group, employees: List[Employee]) -> List[str]:
     encoded_ids = ','.join(user_ids.union(new_ids))
 
     user_ids = set(client.update_usergroup_users(group_id, encoded_ids))
-    updated_ids = user_ids.intersection(new_ids)
     
-    return updated_ids
+    return user_ids
 
 
 def remove_from_slack_group(group: Group, employees: List[Employee]) -> List[str]:
@@ -84,8 +82,7 @@ def remove_from_slack_group(group: Group, employees: List[Employee]) -> List[str
             in Slack or Bugzilla.
         
     Returns:
-        Returns a set of ids of the employees removed to the group. An empty
-        list is retured if no employees are removed.
+        Returns a set of ids of the employees in the group.
     """
     client = slack.SlackClient(token.get_slack_token())
     group_id = group.app_group_id
@@ -95,9 +92,8 @@ def remove_from_slack_group(group: Group, employees: List[Employee]) -> List[str
 
     encoded_ids = ','.join(user_ids - employee_ids)
     user_ids = set(client.update_usergroup_users(group_id, encoded_ids))
-    updated_ids = employee_ids - user_ids
     
-    return updated_ids
+    return user_ids
         
         
 def remove_employee_from_roles(employees, roles):

--- a/views/employees.py
+++ b/views/employees.py
@@ -199,35 +199,39 @@ def remove_employees(ids):
 def add_roles_to_employees():
     
     args = request.get_json()
-    
     if args is None:
-        response = create_error('missing_argument')
-        return (response, 404)
-       
-    updated_employees = []
-    groups_to_update = []
+        response = create_error('no_args')
+        return (response, 400)
+      
+    if args.get("role_ids") is None:
+        response = create_error('missing_argument', 'role_ids argument is missing')
+        return(response, 400)
+        
+    if args.get("employee_ids") is None:
+        response = create_error('missing_argument', 'employee_ids argument is missing')
+        return(response, 400)
     
     try:
-        for employees_id in args["employee_ids"]:
-            employee = query.get_employee_by_id(employees_id)
-            if employee:
-                for role_id in args["role_ids"]:
-                    print(role_id)
-                    role = query.get_role_by_id(role_id)
-                    groups_to_update = query.get_roles_groups(role_id)
-                    print(role)
-                    if role:
-                        #employee.roles.append(role)
-                        is_updated = query.update_role(role)
-                        employee = [employee]
-                        #add the sync line of code
-                        for group in groups_to_update:
-                            print(group)
-                            sync.add_to_slack_group(group, employee)
-                if is_updated:
-                    updated_employees.append(employees_id)
-                    
-        return (json.dumps({"ok": True, "roles": updated_employees}), 200)
+        roles = query.get_roles_with_ids(args.get("role_ids", []))
+        employees = query.get_employees_with_ids(args.get("employee_ids", []))
+        for role in roles:
+            updated_ids = set()
+            groups = query.get_role_groups(role.id)
+            for group in groups:
+                ids = sync.add_to_slack_group(group, employees)
+                updated_ids = updated_ids.union(ids)
+               
+            # Add the role to the employee when at least one of the groups was
+            # added to them
+            for employee in employees:
+                if employee.id in updated_ids:
+                    employee.roles.append(role)
+                
+        # TODO: Come up with the type of output we should give the client
+        for updated_id in updated_ids:
+            pass
+
+        return (json.dumps({"ok": True}), 200)
         
     except Exception as e:
         response = create_error('unexpected_error', e)

--- a/views/employees.py
+++ b/views/employees.py
@@ -215,20 +215,24 @@ def add_roles_to_employees():
         roles = query.get_roles_with_ids(args.get("role_ids", []))
         employees = query.get_employees_with_ids(args.get("employee_ids", []))
         for role in roles:
-            updated_ids = set()
+            matching_ids = set()
             groups = query.get_role_groups(role.id)
             for group in groups:
                 ids = sync.add_to_slack_group(group, employees)
-                updated_ids = updated_ids.union(ids)
-               
+                if matching_ids:
+                    matching_ids.intersection(ids)
+                else:
+                    matching_ids = ids
+            
             # Add the role to the employee when at least one of the groups was
             # added to them
             for employee in employees:
-                if employee.id in updated_ids:
+                if employee.slack_id in matching_ids:
                     employee.roles.append(role)
+                    query.update_employee(employee)
                 
         # TODO: Come up with the type of output we should give the client
-        for updated_id in updated_ids:
+        for matching_id in matching_ids:
             pass
 
         return (json.dumps({"ok": True}), 200)

--- a/views/employees.py
+++ b/views/employees.py
@@ -212,10 +212,14 @@ def add_roles_to_employees():
             if employee:
                 for role_id in args["role_ids"]:
                     role = query.get_role_by_id(role_id)
+                    group = query.get_roles_groups(role_id)
+                    print(group)
                     print(role)
                     if role:
-                        employee.roles.append(role)
+                        #employee.roles.append(role)
                         is_updated = query.update_role(role)
+                        # add the sync line of code
+                        # sync.add_to_slack_group
                 if is_updated:
                     updated_employees.append(employees_id)
                     

--- a/views/employees.py
+++ b/views/employees.py
@@ -205,21 +205,25 @@ def add_roles_to_employees():
         return (response, 404)
        
     updated_employees = []
+    groups_to_update = []
     
     try:
         for employees_id in args["employee_ids"]:
             employee = query.get_employee_by_id(employees_id)
             if employee:
                 for role_id in args["role_ids"]:
+                    print(role_id)
                     role = query.get_role_by_id(role_id)
-                    group = query.get_roles_groups(role_id)
-                    print(group)
+                    groups_to_update = query.get_roles_groups(role_id)
                     print(role)
                     if role:
                         #employee.roles.append(role)
                         is_updated = query.update_role(role)
-                        # add the sync line of code
-                        # sync.add_to_slack_group
+                        employee = [employee]
+                        #add the sync line of code
+                        for group in groups_to_update:
+                            print(group)
+                            sync.add_to_slack_group(group, employee)
                 if is_updated:
                     updated_employees.append(employees_id)
                     

--- a/views/roles.py
+++ b/views/roles.py
@@ -170,7 +170,7 @@ def add_groups_to_roles():
                         role.groups.append(group)
                         is_updated = query.update_role(role)
                         employees = query.get_employees_by_role(role)
-                        sync.add_to_slack_group(group, employees)
+                        #sync.add_to_slack_group(group, employees)
                 if is_updated:
                     updated_roles.append(role_id)
                     


### PR DESCRIPTION
**Description:**
An employee can now be given a role through the user interface and will be added to the corresponding groups on Slack. 

**Test Plan:**
On the employee page, select "Add Role" from the action drop down menu. Select a role that is connected to groups from Slack. Select an employee or more. Click save. Afterwards, check that the employee has been added on Slack.