### PR TITLE
Connect role group editing to slack

### DIFF
--- a/apis/token.py
+++ b/apis/token.py
@@ -1,4 +1,4 @@
-import os, requests
+import os
 
 def get_slack_token():
     """Function used to obtain the Slack token

--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,6 @@ machine:
         version: 3.4.3
 
         
+test:
+    override:
+        - python -m tests.slack_test

--- a/db/query.py
+++ b/db/query.py
@@ -468,7 +468,7 @@ def get_employees_by_role(role: Role) -> List[Employee]:
     employees = []
     session = Session()
     try:
-        employees = session.query(Employee).filter(Role.id == role.id).all()
+        employees = session.query(Employee).join(EmployeeToRole).filter(EmployeeToRole.role_id == role.id).all()
     
     except Exception as e:
         print(e)

--- a/tests/slack_test.py
+++ b/tests/slack_test.py
@@ -1,0 +1,20 @@
+import unittest
+from apis import slack
+from apis import token
+
+class TestSlackConnection(unittest.TestCase):
+    
+    
+    def test_get_slack_token(self):
+        slack_token = token.get_slack_token()
+        self.assertIsNotNone(slack_token)
+    
+    
+    def test_client_init(self):
+        slack_token = token.get_slack_token()
+        client = slack.SlackClient(slack_token)
+        self.assertIsNotNone(client)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/views/roles.py
+++ b/views/roles.py
@@ -163,9 +163,9 @@ def add_groups_to_roles():
                     if group:
                         role.groups.append(group)
                         is_updated = query.update_role(role)
-                        employees = query.get_employees_by_role(role)
-                        #sync.add_to_slack_group(group, employees)
                 if is_updated:
+                    employees = query.get_employees_by_role(role)
+                    sync.add_to_slack_group(group, employees)
                     updated_roles.append(role_id)
                     
         return (json.dumps({"ok": True, "roles": updated_roles}), 200)


### PR DESCRIPTION
**Description:**
When an existing role receives a new group, then employees with that role will be added to the correct group on Slack.

**Test Plan:**
1. Go to Slack and remove everyone except for one person on each Slack group. 
2. From the database remove any roles employees have. 
3. From the roles page create a new role and add a group to it. 
4. Give an employee the new role that was created. 
5. Verify they are added to the appropriate groups. 
6. Add another group to the new role. 
7. Verify on Slack the user was added to the group.